### PR TITLE
Change real_containing_oneof() back to containing_oneof() since the f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ protoc --version
 
 If not installed or you wish to upgrade please follow Google's C++ installation instructions [here](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
 
-There are also numerous packaged versions of protobuf (apt-get, brew, anaconda) which can be used. However, there is a large variation in the versions provided (particularly when using `apt-get` which is highly disto dependent). You should ensure that any packaged installation includes the protoc compiler, headers and libprotobuf.
+There are also numerous packaged versions of protobuf (apt-get, brew, anaconda) which can be used. You should ensure that any packaged installation includes the protoc compiler, headers and libprotobuf and was build with `-fPIC` since we are building a shared object.  There is also a large variation in the versions provided (particularly when using `apt-get` which is highly disto dependent).
 
 
 

--- a/src/MessageFormat.cpp
+++ b/src/MessageFormat.cpp
@@ -40,7 +40,7 @@ K MessageFormat::GetMessageField(const gpb::Message& msg, const gpb::FieldDescri
   // Field -> discriminated kdb type
   K element;
   const auto refl = msg.GetReflection();
-  const auto oneof_desc = fd->real_containing_oneof();
+  const auto oneof_desc = fd->containing_oneof();
   if (oneof_desc != nullptr && refl->GetOneofFieldDescriptor(msg, oneof_desc) != fd) {
     // Field is a oneof but not the active oneof - return empty mixed list.
     element = knk(0);
@@ -101,7 +101,7 @@ void MessageFormat::SetMessageField(gpb::Message* msg, const gpb::FieldDescripto
 {
   // Discriminated kdb type -> field
   const auto& refl = msg->GetReflection();
-  const auto oneof_desc = fd->real_containing_oneof();
+  const auto oneof_desc = fd->containing_oneof();
   if (oneof_desc != nullptr && k_field->t == 0 && k_field->n == 0) {
     // Field is a oneof but not the active oneof.  Do not set the field,
     // otherwise it would override the active oneof if it has already been


### PR DESCRIPTION
…ormer is only supported is very recent protobuf versions.

Add a further proviso to using packaged versions of protobuf (ubuntu 18.04 libprotobuf-dev / protobuf-compiler don't seem to work due to symbol relocation errors when linking)