### PR TITLE
trusty depreciated on travis - newer build sys inc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ jobs:
   include:
   - dist: xenial
     os: linux
-  - dist: trusty 
+  - dist: focal
     os: linux
   - dist: bionic
     os: linux
@@ -96,6 +96,5 @@ deploy:
   file: "$FILE_NAME"
   on:
     tags: true
-    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = trusty && $TRAVIS_OS_NAME = linux) 
+    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = xenial && $TRAVIS_OS_NAME = linux)
   skip_cleanup: 'true'
-  


### PR DESCRIPTION
Trusty is depreciated ( https://docs.travis-ci.com/user/enterprise/trusty/ ). Updated to use next newer os. Added newest supported os also.