### PR TITLE
imported docs prior to removal from code.kx.com 2023.03.01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 proto/google
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This interface allows kdb+ users to parse data which has been encoded using Google Protocol Buffers [(protobuf)](https://github.com/protocolbuffers/protobuf) into kdb+ according to the proto schema and serialise it back to the encoded wire format. The interface utilises the `libprotobuf` descriptor and reflection C++ [APIs](https://developers.google.com/protocol-buffers/docs/reference/cpp#google.protobuf).
 
-This is part of the [*Fusion for kdb+*](http://code.kx.com/q/interfaces#fusion) interface collection.
+This is part of the [*Fusion for kdb+*](http://code.kx.com/q/interfaces/#fusion-interfaces) interface collection.
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,25 @@
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/kxsystems/protobufkdb?include_prereleases)](https://github.com/kxsystems/protobufkdb/releases) [![Travis (.org) branch](https://img.shields.io/travis/kxsystems/protobufkdb/master?label=travis%20build)](https://travis-ci.org/kxsystems/protobufkdb/branches)
 
-## Introduction
 
-This interface allows kdb+ users to parse data which has been encoded using Google Protocol Buffers [(protobuf)](https://github.com/protocolbuffers/protobuf) into kdb according to the proto schema and serialise it back to the encoded wire format. The interface utilises the libprotobuf descriptor and reflection C++  [APIs](https://developers.google.com/protocol-buffers/docs/reference/cpp#google.protobuf).
 
-This is part of the [*Fusion for kdb+*](http://code.kx.com/q/interfaces/fusion/) interface collection.
+This interface allows kdb+ users to parse data which has been encoded using Google Protocol Buffers [(protobuf)](https://github.com/protocolbuffers/protobuf) into kdb+ according to the proto schema and serialise it back to the encoded wire format. The interface utilises the `libprotobuf` descriptor and reflection C++ [APIs](https://developers.google.com/protocol-buffers/docs/reference/cpp#google.protobuf).
+
+This is part of the [*Fusion for kdb+*](http://code.kx.com/q/interfaces#fusion) interface collection.
 
 
 
 ## New to kdb+ ?
 
-Kdb+ is the world's fastest time-series database, optimized for  ingesting, analyzing and storing massive amounts of structured data. To  get started with kdb+, please visit https://code.kx.com/q/learn/ for downloads and developer information. For general information, visit https://kx.com/
-
+Kdb+ is the world’s fastest timeseries database, optimized for ingesting, analyzing and storing massive amounts of structured data. To  get started with kdb+, visit https://code.kx.com/q/learn/ for downloads and developer information. For general information, visit https://kx.com/
 
 
 ## New to Protocol Buffers ?
 
-Protocol Buffers (Protobuf) is a language-neutral, platform-neutral, extensible mechanism for serializing structured data. It is used both in the development of programs which are required to communicate over the wire or for data storage. Developed originally for internal use by Google, it is released under an open source BSD license. The core principle behind this data format is to allow a user to define the expected structure of their data and incorporate this within specially generated source code. This allows a user to easily read and write structured data to and from a variety of languages. You can find [protobuf's documentation on the Google Developers site](https://developers.google.com/protocol-buffers/docs/overview).
+Protocol Buffers (Protobuf) is a language-neutral, platform-neutral, extensible mechanism for serializing structured data. It is used both in the development of programs which are required to communicate over the wire or for data storage. Developed originally for internal use by Google, it is released under an open source BSD license. The core principle behind this data format is to allow a user to define the expected structure of their data and incorporate this within specially generated source code. This allows a user to easily read and write structured data to and from a variety of languages. 
+
+:globe_with_meriidians:
+[Protobuf documentation](https://developers.google.com/protocol-buffers/docs/overview)
 
 
 
@@ -28,9 +30,9 @@ Protobuf messages are defined in a `.proto` schema file and these message defini
 
 ### 1.  Compiling in the generated message definitions
 
-Normally the protocol buffers compiler is used to generate source code from the `.proto` schema files which is then compiled in to the binary:
+Normally the Protocol Buffers compiler is used to generate source code from the `.proto` schema files which is then compiled in to the binary:
 
-protoc compiles your message definitions based on a file defined as:
+`protoc` compiles your message definitions based on a file defined as:
 
 ```bash
 <schema>.proto
@@ -43,15 +45,15 @@ producing both a C++ source and header file defined as:
 <schema>.pb.h
 ```
 
-These files contain the classes and metadata which describe the schema and the functionality required to serialise to and parse from this schema.
+These files contain the classes and metadata which describe the schema and the functionality required to serialize to and parse from this schema.
 
 This mechanism is more performant but does require that protobufkdb be built from source since the binary needs to be rebuilt to change the statically available messages.
 
 ### 2.  Dynamically importing the message definitions at runtime
 
-In order to provide greater flexibility and usability it is also possible to dynamically import a `.proto` schema file at runtime from within the q session.  Imported message definitions can then be used subsequently by the interface and behave similarly to compiled in ones (the import procedure leverages the same functionality as used by the protobuf compiler).
+To provide greater flexibility and usability it is also possible to dynamically import a `.proto` schema file at runtime from within the q session.  Imported message definitions can then be used subsequently by the interface and behave similarly to compiled in ones (the import procedure leverages the same functionality as used by the protobuf compiler).
 
-If only dynamically imported message definitions are required then the packaged installation of protobufkdb can be used.  However, importing message definitions is less performant - in addition to the one off import cost there is also an overhead from the subsequent use of these dynamically created messages (approx. 10% for parsing, 20% for serialising).  Alternatively a hybrid approach can be employed where dynamic messages are used during development until the schemas are finalised at which point they are compiled into the interface.
+If only dynamically imported message definitions are required then the packaged installation of protobufkdb can be used.  However, importing message definitions is less performant - in addition to the one-off import cost, there is also an overhead from the subsequent use of these dynamically created messages (approx. 10% for parsing, 20% for serializing).  Alternatively a hybrid approach can be employed where dynamic messages are used during development until the schemas are finalized, at which point they are compiled into the interface.
 
 
 
@@ -59,7 +61,7 @@ If only dynamically imported message definitions are required then the packaged 
 
 ### Requirements
 
-- kdb+ ≥ 3.5 64-bit (Linux/MacOS/Windows)
+- kdb+ ≥ 3.5 64-bit (Linux/macOS/Windows)
 - protobuf ≥ 3.0 (recommended [^1])
 - C++11 or later [^2] 
 - CMake ≥ 3.1 [^2]
@@ -70,137 +72,137 @@ If only dynamically imported message definitions are required then the packaged 
 
 ### Installing a release
 
-The protobufkdb releases are linked statically against libprotobuf to avoid potential C++ ABI [compatibility issues](https://github.com/protocolbuffers/protobuf/tree/master/src#binary-compatibility-warning) with different versions of libprotobuf.  Therefore it is not necessary to install protobuf separately when used a packaged release.
+The protobufkdb releases are linked statically against libprotobuf to avoid potential C++ ABI [compatibility issues](https://github.com/protocolbuffers/protobuf/tree/master/src#binary-compatibility-warning) with different versions of libprotobuf.  Therefore it is unnecessary to install protobuf separately when used a packaged release.
 
-1. Download a release from [here](https://github.com/KxSystems/protobufkdb/releases)
+1.  Download a release from [here](https://github.com/KxSystems/protobufkdb/releases)
 
-2. Install required q executable script `q/protobufkdb.q` and binary file `lib/protobufkdb.(so|dll)` to `$QHOME` and `$QHOME/[mlw](64)`, by executing the following from the Release directory
+2.  Install required q executable script `q/protobufkdb.q` and binary file `lib/protobufkdb.(so|dll)` to `$QHOME` and `$QHOME/[mlw](64)`, by executing the following from the Release directory
 
-   ```bash
-   ## Linux/MacOS
-   chmod +x install.sh && ./install.sh
+    ```bash
+    ## Linux/MacOS
+    chmod +x install.sh && ./install.sh
    
-   ## Windows
-   install.bat
-   ```
+    ## Windows
+    install.bat
+    ```
 
-3. If you wish to use the KdbTypeSpecifier field option (described below) with dynamic messages then the directory containing `kdb_type_specifier.proto` must be specified to the interface as an import search location.  In the release package `kdb_type_specifier.proto` (and its dependencies) are found in the `proto` subdirectory.  Import paths can be relative or absolute.  For example, if the q session is started from the root of the release package run:
+3.  If you wish to use the KdbTypeSpecifier field option (described below) with dynamic messages then the directory containing `kdb_type_specifier.proto` must be specified to the interface as an import search location.  In the release package `kdb_type_specifier.proto` (and its dependencies) are found in the `proto` subdirectory.  Import paths can be relative or absolute.  For example, if the q session is started from the root of the release package run:
 
-   ```
-   q).protobufkdb.addProtoImportPath["proto"]
-   ```
+    ```
+    q).protobufkdb.addProtoImportPath["proto"]
+    ```
 
 ### Building and installing from source
 
-#### Third-Party Library Installation
+#### Third-party library installation
 
-Protobufkdb requires the full protocol buffers runtime (protoc compiler, libprotobuf and its header files) to be installed on your system.  Many packaged installations only contain a subset of the required functionality or use an incompatible build.  Furthermore, version mismatches can occur between protoc and libprotobuf if a new installation is applied on top of an existing one.  
+Protobufkdb requires the full Protocol Buffers runtime (protoc compiler, libprotobuf and its header files) to be installed on your system.  Many packaged installations only contain a subset of the required functionality or use an incompatible build.  Furthermore, version mismatches can occur between protoc and libprotobuf if a new installation is applied on top of an existing one.  
 
-It is therefore recommend that the protocol buffer runtime is built from source and installed to a non-system directory.  This directory can then be specified to the protobufkdb build so it will use that protocol buffers installation in preference to any existing system installs.
+It is therefore recommend that the protocol buffer runtime is built from source and installed to a non-system directory.  This directory can then be specified to the protobufkdb build so it will use that Protocol Buffers installation in preference to any existing system installs.
 
-#### Building protocol buffers - Linux/MacOS
+#### Building Protocol Buffers - Linux/macOS
 
-The tools required to build protocol buffers from source on Linux/MacOS are described [here](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
+The tools required to build Protocol Buffers from source on Linux/macOS are described [here](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md).
 
-However, do not build protocol buffers using Google's `configure` script since that will create a debug version of `libprotobuf.a` which protobufkdb links against.  Rather, follow the instructions below to build protocol buffers using CMake with the correct compiler flags and install it to a non-system directory.
+However, do not build Protocol Buffers using Google's `configure` script, since that will create a debug version of `libprotobuf.a` which protobufkdb links against.  Rather, follow the instructions below to build Protocol Buffers using CMake with the correct compiler flags and install it to a non-system directory.
 
-Clone the protocol buffers source from github:
+Clone the Protocol Buffers source from GitHub:
 
 ```bash
-$ git clone https://github.com/protocolbuffers/protobuf.git
-$ cd protobuf
+git clone https://github.com/protocolbuffers/protobuf.git
+cd protobuf
 ```
 
 Create an install directory and set an environment variable to this directory (this is used again later when building protobufkdb):
 
 ```bash
-$ mkdir install
-$ export PROTOBUF_INSTALL=$(pwd)/install
+mkdir install
+export PROTOBUF_INSTALL=$(pwd)/install
 ```
 
 Create the CMake build directory and generate the build files, specifying position independent code (otherwise symbol relocation errors will occur during linking of protobufkdb):
 
 ```bash
-$ mkdir cmake/build
-$ cd cmake/build
-$ cmake -DCMAKE_BUILD_TYPE=Release -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$PROTOBUF_INSTALL ..
+mkdir cmake/build
+cd cmake/build
+cmake -DCMAKE_BUILD_TYPE=Release -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$PROTOBUF_INSTALL ..
 ```
 
-Finally build and install protocol buffers:
+Finally build and install Protocol Buffers:
 
 ```bash
-$ cmake --build . --config Release
-$ cmake --build . --config Release --target install
+cmake --build . --config Release
+cmake --build . --config Release --target install
 ```
 
-#### Building protocol buffers - Windows
+#### Building Protocol Buffers - Windows
 
-The tools required to build protocol buffers from source on Windows are described [here](https://github.com/protocolbuffers/protobuf/blob/master/cmake/README.md) and details on how to setup your environment to build with VS2019 are [here](https://github.com/protocolbuffers/protobuf/blob/master/cmake/README.md#environment-setup). Then follow the below instructions to build a Release version protocol buffers and install it to a non-system directory.
+The tools required to build Protocol Buffers from source on Windows are described [here](https://github.com/protocolbuffers/protobuf/blob/master/cmake/README.md) and details on how to setup your environment to build with VS2019 are [here](https://github.com/protocolbuffers/protobuf/blob/master/cmake/README.md#environment-setup). Then follow the below instructions to build a Release version Protocol Buffers and install it to a non-system directory.
 
-From a Visual Studio command prompt, clone the protocol buffers source from github:
+From a Visual Studio command prompt, clone the Protocol Buffers source from github:
 
-```bash
+```shell
 C:\Git> git clone https://github.com/protocolbuffers/protobuf.git
 C:\Git> cd protobuf
 ```
 
 Create an install directory and set an environment variable to this directory (substituting the correct absolute path as appropriate).  This environment variable is used again later when building protobufkdb:
 
-```bash
+```shell
 C:\Git\protobuf> mkdir install
 C:\Git\protobuf> set PROTOBUF_INSTALL=C:\Git\protobuf\install
 ```
 
-Create the CMake build directory (note that if you also wish to build a Debug version of protocol buffers then a second CMake build directory is required):
+Create the CMake build directory (note that if you also wish to build a Debug version of Protocol Buffers then a second CMake build directory is required):
 
-```bash
+```shell
 C:\Git\protobuf> mkdir cmake\release_build
 C:\Git\protobuf> cd cmake\release_build
 ```
 
 Generate the build files (this will default to using the Visual Studio CMake generator when run from a VS command prompt):
 
-```bash
+```shell
 C:\Git\protobuf\cmake\release_build> cmake -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=%PROTOBUF_INSTALL% ..
 ```
 
-Finally build and install protocol buffers:
+Finally build and install Protocol Buffers:
 
-```bash
+```shell
 C:\Git\protobuf\cmake\release_build> cmake --build . --config Release
 C:\Git\protobuf\cmake\release_build> cmake --build . --config Release --target install
 ```
 
 #### Add the protobuf schema files to the build procedure
 
-protobufkdb uses a factory to create a message class object of the correct type from the message type string passed from kdb.  The lookup requires that the message type string passed from kdb is the same as the message name in its .proto definition.
+Protobufkdb uses a factory to create a message class object of the correct type from the message type string passed from kdb.  The lookup requires that the message type string passed from kdb is the same as the message name in its .proto definition.
 
 In order to populate the factory, the .proto files for all messages to be serialised/parsed must be incorporated into the build as follows:
 
-1. Place the new `<schema>.proto` file into the `src/` subdirectory
-2. Edit `src/CMakeLists.txt` file, adding the new .proto file to the line below the following comment:
+1.  Place the new `<schema>.proto` file into the `src/` subdirectory
+2.  Edit `src/CMakeLists.txt` file, adding the new .proto file to the line below the following comment:
 
-  ```cmake
-  # ### GENERATE PROTO FILES ###
-  ```
+    ```cmake
+    # ### GENERATE PROTO FILES ###
+    ```
 
-  For example, to add `examples.proto` (which is already present in the `src/` subdirectory), in addition to the existing `tests.proto`, change:
+    For example, to add `examples.proto` (which is already present in the `src/` subdirectory), in addition to the existing `tests.proto`, change:
 
-  ```cmake
-  set(MY_PROTO_FILES tests.proto)
-  ```
+    ```cmake
+    set(MY_PROTO_FILES tests.proto)
+    ```
 
-  to:
+    to:
 
-  ```cmake
-  set(MY_PROTO_FILES tests.proto examples.proto)
-  ```
+    ```cmake
+    set(MY_PROTO_FILES tests.proto examples.proto)
+    ```
 
-**Note:** `MY_PROTO_FILES` is a CMake space separated list, do not wrap the list of .proto files in a string.
+**Note:** `MY_PROTO_FILES` is a CMake-space separated list; do not wrap the list of `.proto` files in a string.
 
 #### Building protobufkdb
 
-A CMake script is provided to build protobufkdb. This uses the CMake functionality to locate the protobuf installation on your system.  By setting the CMake environment variable `CMAKE_PREFIX_PATH` to the protocol buffers installation directory created above when building protobuf from source, CMake will use this installation in preference to any existing system installs.  This avoids issues with existing incompatible or mismatched protobuf installs.
+A CMake script is provided to build protobufkdb. This uses the CMake functionality to locate the protobuf installation on your system.  By setting the CMake environment variable `CMAKE_PREFIX_PATH` to the Protocol Buffers installation directory created above when building protobuf from source, CMake will use this installation in preference to any existing system installs.  This avoids issues with existing incompatible or mismatched protobuf installs.
 
 From the root of this repository create and move into a directory in which to perform the build:
 
@@ -232,9 +234,9 @@ cmake --build . --config Release --target install
 
 **Note:**  By default `src/CMakeLists.txt` is configured to link statically against libprotobuf to avoid potential C++ ABI [compatibility issues](https://github.com/protocolbuffers/protobuf/tree/master/src#binary-compatibility-warning) with different versions of libprotobuf.  This is a particular issue on [Windows](https://github.com/protocolbuffers/protobuf/blob/master/cmake/README.md#dlls-vs-static-linking).
 
-#### Build Issues
+#### Build issues
 
-Because the protobufkdb interface uses both the protoc compiler and the protocol buffer's runtime, the versions of protoc, libprotobuf and its header files must be consistent and installed from the same build.  Otherwise build errors can occur when compiling any of the proto-generated `.pb.h` or `.pb.cc` files.  To help identify these problems the protobufkdb CMake scripts will log the locations of the protocol buffers installation it has found.  For example:
+Because the protobufkdb interface uses both the protoc compiler and the Protocol Buffers’ runtime, the versions of protoc, libprotobuf and its header files must be consistent and installed from the same build.  Otherwise build errors can occur when compiling any of the proto-generated `.pb.h` or `.pb.cc` files.  To help identify these problems the protobufkdb CMake scripts log the locations of the Protocol Buffers installation it has found.  For example:
 
 ```bash
 [build]$ cmake ..
@@ -261,11 +263,11 @@ Because the protobufkdb interface uses both the protoc compiler and the protocol
 
 indicates it found protoc version 3.11.4 at `/home/protobuf/install/bin/protoc` but version 3.7.1 of `libprotobuf.a` (and the headers) installed on the system under `/usr/local/`.  This can occur if there was a conflicting packaged version of protobuf already on the system and will likely cause the protobufkdb build to fail.  
 
-The solution, as described above, is to build the protocol buffers runtime from source, install it to non-system directory then specify that directory when building protobufkdb.
+The solution, as described above, is to build the Protocol Buffers runtime from source, install it to non-system directory then specify that directory when building protobufkdb.
 
-#### Docker - Linux
+#### Docker – Linux
 
-A sample docker file is provided in the `docker_linux` directory to create a Ubuntu 18.04 LTS environment (including downloading and building the protocol buffers runtime from source) before building and installing the kdb+ `protobufkdb` interface.
+A sample Docker file is provided in the `docker_linux` directory to create a Ubuntu 18.04 LTS environment (including downloading and building the Protocol Buffers runtime from source) before building and installing the kdb+ `protobufkdb` interface.
 
 For Docker Windows, the `PROTOBUFKDB_SOURCE` and `QHOME_LINUX` directories are specified at the top of `protobufkdb_build.bat`, which sets up the environment specified in `Dockerfile.build` and invokes `protobufkdb_build.sh` to build the interface.
 
@@ -276,11 +278,11 @@ For Docker Windows, the `PROTOBUFKDB_SOURCE` and `QHOME_LINUX` directories are s
 
 The protobufkdb interface is provided here as a beta release under an Apache 2.0 license.
 
-If you find issues with the interface or have feature requests, please consider raising an issue [here](https://github.com/KxSystems/protobufkdb/issues).
+If you find issues with the interface or have feature requests, please [raise an issue](../../issues).
 
-If you wish to contribute to this project, please follow the contributing guide [here](CONTRIBUTING.md).
+To contribute to this project, please follow the [contribution guide](CONTRIBUTING.md).
 
-Protocol Buffers is used under the terms of [Google's license](https://github.com/protocolbuffers/protobuf/blob/master/LICENSE):
+Protocol Buffers is used under the terms of [Google’s license](https://github.com/protocolbuffers/protobuf/blob/master/LICENSE):
 
 ```txt
 Copyright 2008 Google Inc.  All rights reserved.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Kdb+ is the world’s fastest timeseries database, optimized for ingesting, anal
 
 Protocol Buffers (Protobuf) is a language-neutral, platform-neutral, extensible mechanism for serializing structured data. It is used both in the development of programs which are required to communicate over the wire or for data storage. Developed originally for internal use by Google, it is released under an open source BSD license. The core principle behind this data format is to allow a user to define the expected structure of their data and incorporate this within specially generated source code. This allows a user to easily read and write structured data to and from a variety of languages. 
 
-:globe_with_meriidians:
+:globe_with_meridians:
 [Protobuf documentation](https://developers.google.com/protocol-buffers/docs/overview)
 
 
@@ -86,10 +86,10 @@ The protobufkdb releases are linked statically against libprotobuf to avoid pote
     install.bat
     ```
 
-3.  If you wish to use the KdbTypeSpecifier field option (described below) with dynamic messages then the directory containing `kdb_type_specifier.proto` must be specified to the interface as an import search location.  In the release package `kdb_type_specifier.proto` (and its dependencies) are found in the `proto` subdirectory.  Import paths can be relative or absolute.  For example, if the q session is started from the root of the release package run:
+3.  To use the KdbTypeSpecifier field option (described below) with dynamic messages then the directory containing `kdb_type_specifier.proto` must be specified to the interface as an import search location.  In the release package `kdb_type_specifier.proto` (and its dependencies) are found in the `proto` subdirectory.  Import paths can be relative or absolute.  For example, if the q session is started from the root of the release package run:
 
     ```
-    q).protobufkdb.addProtoImportPath["proto"]
+    .protobufkdb.addProtoImportPath["proto"]
     ```
 
 ### Building and installing from source
@@ -238,7 +238,7 @@ cmake --build . --config Release --target install
 
 Because the protobufkdb interface uses both the protoc compiler and the Protocol Buffers’ runtime, the versions of protoc, libprotobuf and its header files must be consistent and installed from the same build.  Otherwise build errors can occur when compiling any of the proto-generated `.pb.h` or `.pb.cc` files.  To help identify these problems the protobufkdb CMake scripts log the locations of the Protocol Buffers installation it has found.  For example:
 
-```bash
+```txt
 [build]$ cmake ..
  -- The CXX compiler identification is GNU 4.8.5
  -- Check for working CXX compiler: /usr/bin/c++

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+---
+title: Protobufkdb | Interfaces | Documentation for kdb+ and q
+description: Protobuf/Google Protocol Buffers is a flexible data-interchange mechanism for serializing/deserializing structured data wherever programs or services have to store or exchange data via interfaces 
+---
+
+# Protobufkdb
+
+:fontawesome-brands-github: 
+[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
+
+Protobuf/Google Protocol Buffers is a flexible data-interchange mechanism for serializing/deserializing structured data wherever programs or services have to store or exchange data via interfaces while maintaining a high degree of language interoperability.  The binary-encoded format used to represent the data is considerably more efficient, both in terms of raw processing speed and compact data size, than other encodings such as JSON or XML.
+
+Protocol Buffers is supported across a wide variety of programming languages (including C++, C#, Java and Python), enabling communication between separate applications and platforms though a simple common structured schema.  Using this schema, the protocol buffer’s compiler generates source code in the language of choice, which is used to serialize and deserialize the binary encoded data.  This substantially reduces the boilerplate code which is otherwise required to convert between the messaging data format and your language's native structures.
+
+:fontawesome-brands-google:
+[Google developers’ page](https://developers.google.com/protocol-buffers/)
+
+
+## Protobuf/kdb+ integration
+
+This interface allows a user to serialize/deserialize Protobuf messages from a kdb+ session via reference to loaded schema files. This interface supports two methods of loading a schema file which have associated pros and cons:
+
+Incorporate the schema into a shared library at compile time
+
+: This is the most performant form of loading a schema file although it is inflexible.
+
+Load a schema file from a kdb+ session dynamically
+
+: This is a more flexible option giving the option to modify schema files without re-compiling the library. This option is approximately 10% to 20% less performant than the compiled version.
+
+In addition to this a user can also assign serialized data to a kdb+ variable or save it to a file. Similarly you can deserialize Protobuf data from a kdb+ variable or a file.
+
+:fontawesome-solid-hand-point-right:
+[Function reference](reference.md), [example implementations](examples.md)
+
+
+## Install Protobufkdb
+
+:fontawesome-brands-github: 
+[Installation guide](https://github.com/KxSystems/protobufkdb#installation)
+
+
+## Status
+
+The interface is currently available under an Apache 2.0 licence as a beta release and is supported on a best-efforts basis by the Fusion team. 
+This interface is currently in active development, with additional functionality to be released on an ongoing basis.
+
+:fontawesome-brands-github: 
+[Issues and feature requests](https://github.com/KxSystems/protobufkdb/issues) 
+<br>
+:fontawesome-brands-github: 
+[Guide to contributing](https://github.com/KxSystems/protobufkdb/blob/master/CONTRIBUTING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,10 @@
----
-title: Protobufkdb | Interfaces | Documentation for kdb+ and q
-description: Protobuf/Google Protocol Buffers is a flexible data-interchange mechanism for serializing/deserializing structured data wherever programs or services have to store or exchange data via interfaces 
----
-
 # Protobufkdb
-
-:fontawesome-brands-github: 
-[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
 
 Protobuf/Google Protocol Buffers is a flexible data-interchange mechanism for serializing/deserializing structured data wherever programs or services have to store or exchange data via interfaces while maintaining a high degree of language interoperability.  The binary-encoded format used to represent the data is considerably more efficient, both in terms of raw processing speed and compact data size, than other encodings such as JSON or XML.
 
-Protocol Buffers is supported across a wide variety of programming languages (including C++, C#, Java and Python), enabling communication between separate applications and platforms though a simple common structured schema.  Using this schema, the protocol buffer’s compiler generates source code in the language of choice, which is used to serialize and deserialize the binary encoded data.  This substantially reduces the boilerplate code which is otherwise required to convert between the messaging data format and your language's native structures.
+Protocol Buffers is supported across a wide variety of programming languages (including C++, C#, Java and Python), enabling communication between separate applications and platforms though a simple common structured schema.  Using this schema, the Protocol Buffers’ compiler generates source code in the language of choice, which is used to serialize and deserialize the binary encoded data.  This substantially reduces the boilerplate code which is otherwise required to convert between the messaging data format and your language's native structures.
 
-:fontawesome-brands-google:
+:globe_with_meridians:
 [Google developers’ page](https://developers.google.com/protocol-buffers/)
 
 
@@ -20,24 +12,23 @@ Protocol Buffers is supported across a wide variety of programming languages (in
 
 This interface allows a user to serialize/deserialize Protobuf messages from a kdb+ session via reference to loaded schema files. This interface supports two methods of loading a schema file which have associated pros and cons:
 
-Incorporate the schema into a shared library at compile time
+-   Incorporate the schema into a shared library at compile time
 
-: This is the most performant form of loading a schema file although it is inflexible.
+    This is the most performant form of loading a schema file although it is inflexible.
 
-Load a schema file from a kdb+ session dynamically
+-   Load a schema file from a kdb+ session dynamically
 
-: This is a more flexible option giving the option to modify schema files without re-compiling the library. This option is approximately 10% to 20% less performant than the compiled version.
+    This is a more flexible option giving the option to modify schema files without re-compiling the library. This option is approximately 10% to 20% less performant than the compiled version.
 
-In addition to this a user can also assign serialized data to a kdb+ variable or save it to a file. Similarly you can deserialize Protobuf data from a kdb+ variable or a file.
+You can also assign serialized data to a kdb+ variable or save it to a file. Similarly you can deserialize Protobuf data from a kdb+ variable or a file.
 
-:fontawesome-solid-hand-point-right:
+:point_right:
 [Function reference](reference.md), [example implementations](examples.md)
 
 
 ## Install Protobufkdb
 
-:fontawesome-brands-github: 
-[Installation guide](https://github.com/KxSystems/protobufkdb#installation)
+[Installation guide](../README.md#installation)
 
 
 ## Status
@@ -45,8 +36,7 @@ In addition to this a user can also assign serialized data to a kdb+ variable or
 The interface is currently available under an Apache 2.0 licence as a beta release and is supported on a best-efforts basis by the Fusion team. 
 This interface is currently in active development, with additional functionality to be released on an ongoing basis.
 
-:fontawesome-brands-github: 
-[Issues and feature requests](https://github.com/KxSystems/protobufkdb/issues) 
-<br>
-:fontawesome-brands-github: 
-[Guide to contributing](https://github.com/KxSystems/protobufkdb/blob/master/CONTRIBUTING.md)
+
+[Issues and feature requests](../../../issues) 
+
+[Guide to contributing](../../CONTRIBUTING.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,155 @@
+---
+title: Interface example | Protobuf | Interfaces | Documentation for kdb+ and q
+description: Examples of interfacing kdb+ and Protobuf
+---
+# Protobuf/Protocol Buffers interface example
+
+:fontawesome-brands-github:
+[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
+
+It is assumed in the example that you are executing logic in the root of the `protobufkdb` repository. The file structure for the required components from this location is:
+
+```treeview
+./
+├── proto/
+│   ├── google
+│   ├── kdb_type_specifier.proto
+│   └── sample.proto
+└── q/
+    └── protobufkdb.q
+```
+
+Here `sample.proto` is defined as follows:
+
+```protobuf
+syntax = "proto3";
+
+option cc_enable_arenas = true;
+
+import "kdb_type_specifier.proto";
+
+message Office {
+    repeated string name    = 1;
+    double   longtitude     = 2;
+    double   latitude       = 3;
+    int32    accessed       = 4 [(kdb_type) = DATE];
+}
+
+message Region {
+    string region              = 1;
+    map<string, Office> office = 2; 
+}
+```
+
+
+## Load Protobufkdb library
+
+From the root of the repository load the `protobufkdb` library
+
+```q
+q)\l q/protobufkdb.q
+```
+
+
+## Import schema file
+
+When using dynamic import functionality, specify the path of your Proto (schema) files first. As such we tell `protobufkdb` the location of schema files of interest, specifying its path (`"./proto"`) and importing the relevant file (`"sample.proto"`).
+
+!!! detail "This step is not necessary when using a library built from source, where schema files are linked appropriately."
+
+```q
+q).protobufkdb.addProtoImportPath["proto"]
+q).protobufkdb.importProtoFile["sample.proto"]
+```
+
+
+## Check schema file
+
+Ensure the schema file has been imported appropriately. 
+Display the schemas in it.
+
+```q
+q).protobufkdb.displayMessageSchema[`Office]
+message Office {
+  repeated string name = 1;
+  double longtitude = 2;
+  double latitude = 3;
+  int32 accessed = 4 [(.kdb_type) = DATE];
+}
+
+q).protobufkdb.displayMessageSchema[`Region]
+message Region {
+  string region = 1;
+  map<string, .Office> office = 2;
+}
+
+```
+
+
+## Serialize data
+
+A Protobuf message is expressed in a mixed list in q. This data can be serialized to Protobuf provided the message content matches the format of a named target schema.
+
+```q
+// Serialize the details of an office to a Protobuf array
+q)HQ:(("Head_Office";"Brian_Conlon_House"); 54.179127; -6.337371; 2020.03.23)
+q)encodedHQ:.protobufkdb.serializeArrayFromList[`Office; HQ]
+q)encodedHQ
+"\n\013Head_Office\n\022Brian_Conlon_House\021Qj/\242\355\026K@\031\253y\216\..
+
+// Serialize the details of all offices in a region to a Protobuf array using Arenas
+q)newry:(("Newry_Office";"The_Conlon_Building"); 54.1751772; -6.3378739; 2020.08.14)
+q)belfast:(enlist "Belfast"; 54.592595; -5.927475; 2020.08.14)
+q)EMEA:`HQ`Newry`Belfast!(HQ; newry; belfast)
+q)encodedEMEA:.protobufkdb.serializeArrayArenaFromList[`Region; ("EMEA"; EMEA)]
+q)encodedEMEA
+"\n\004EMEA\022<\n\002HQ\0226\n\013Head_Office\n\022Brian_Conlon_House\021Qj/..
+```
+
+
+## Deserialize data
+
+Retrieve the contents of a Protobuf message serialized in the above example.
+
+```q
+// Retrieve encoded information about an office from a Protobuf message
+q).protobufkdb.parseArrayToList[`Office; encodedHQ]
+("Head_Office";"Brian_Conlon_House")
+54.17913
+-6.337371
+2020.03.23
+
+// Retrieve encoded information about a region from a Protobuf message using Arenas
+q).protobufkdb.parseArrayArenaToList[`Region; encodedEMEA]
+"EMEA"
+`HQ`Newry`Belfast!((("Head_Office";"Brian_Conlon_House");54.17913;-6.337371;2..
+```
+
+
+## Save serialized data
+
+You can serialize and save data to a file by specifying a target schema and the target file name.
+
+```q
+q).protobufkdb.saveMessageFromList[`Office; "proto/record_HQ"; HQ]
+```
+
+
+## Load serialized data
+
+Retrieve data serialized and saved to a file based on a specified schema.
+
+```q
+q).protobufkdb.loadMessageToList[`Office; "proto/record_HQ"]
+("Head_Office";"Brian_Conlon_House")
+54.17913
+-6.337371
+2020.03.23
+```
+
+
+More examples:
+:fontawesome-brands-github: 
+[protobufkdb/examples](https://github.com/KxSystems/protobufkdb/tree/master/examples)
+
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,13 +1,6 @@
----
-title: Interface example | Protobuf | Interfaces | Documentation for kdb+ and q
-description: Examples of interfacing kdb+ and Protobuf
----
 # Protobuf/Protocol Buffers interface example
 
-:fontawesome-brands-github:
-[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
-
-It is assumed in the example that you are executing logic in the root of the `protobufkdb` repository. The file structure for the required components from this location is:
+It is assumed here that you are executing logic in the root of the `protobufkdb` repository. The file structure for the required components from this location is:
 
 ```treeview
 ./
@@ -47,7 +40,7 @@ message Region {
 From the root of the repository load the `protobufkdb` library
 
 ```q
-q)\l q/protobufkdb.q
+\l q/protobufkdb.q
 ```
 
 
@@ -55,11 +48,11 @@ q)\l q/protobufkdb.q
 
 When using dynamic import functionality, specify the path of your Proto (schema) files first. As such we tell `protobufkdb` the location of schema files of interest, specifying its path (`"./proto"`) and importing the relevant file (`"sample.proto"`).
 
-!!! detail "This step is not necessary when using a library built from source, where schema files are linked appropriately."
+> This step is not necessary when using a library built from source, where schema files are linked appropriately.
 
 ```q
-q).protobufkdb.addProtoImportPath["proto"]
-q).protobufkdb.importProtoFile["sample.proto"]
+.protobufkdb.addProtoImportPath["proto"]
+.protobufkdb.importProtoFile["sample.proto"]
 ```
 
 
@@ -131,7 +124,7 @@ q).protobufkdb.parseArrayArenaToList[`Region; encodedEMEA]
 You can serialize and save data to a file by specifying a target schema and the target file name.
 
 ```q
-q).protobufkdb.saveMessageFromList[`Office; "proto/record_HQ"; HQ]
+.protobufkdb.saveMessageFromList[`Office; "proto/record_HQ"; HQ]
 ```
 
 
@@ -147,9 +140,7 @@ q).protobufkdb.loadMessageToList[`Office; "proto/record_HQ"]
 2020.03.23
 ```
 
-
-More examples:
-:fontawesome-brands-github: 
-[protobufkdb/examples](https://github.com/KxSystems/protobufkdb/tree/master/examples)
+:point_right:
+[More examples](../examples/README.md)
 
 

--- a/docs/protobuf-types.md
+++ b/docs/protobuf-types.md
@@ -1,0 +1,317 @@
+---
+title: Datatype mappings | Protobuf | Interfaces | Documentation for kdb+ and q
+author: Conor McCarthy
+description: Datatype mappings between kdb+ and Protobuf
+date: September 2020
+---
+# Type mapping between kdb+ and Protobuf 
+
+:fontawesome-brands-github:
+[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
+
+
+
+
+We describe how q numeric and string types are represented in Protobuf, how Protobuf structures are mapped to q.
+
+## Protobuf/q mapping
+
+A Protobuf message is composed of a number of fields where each field can be scalar, repeated scalar, sub-message, repeated sub-message, enum or map. For example:
+
+```protobuf
+message MyMessage {
+  int32 scalar_int = 1;
+  repeated double repeated_double = 2;
+  MyMessage sub_message = 3;
+  repeated MyMessage repeated_msg = 4;
+  enum EnumType {
+    ZERO = 0;
+    ONE = 1;
+  }
+  EnumType enum_field = 5;
+  map<int64, string> int_str = 6;
+}
+```
+
+A Protobuf message is represented in q using a mixed list with length equal to the number of fields in the message. The fields are iterated in the order they are declared in the message definition, which may differ from the field number tags.
+
+The q type used for each list item depends on the field type:
+
+```txt
+field type            kdb+ structure        
+--------------------------------------------
+Scalar                Atom                  
+Repeated scalar       Simple list           
+Sub-message           Mixed list            
+Repeated Sub-message  List of mixed lists   
+Enum                  Integer of enum value 
+Map                   Dictionary            
+```
+
+Where on serialization you do not wish to explicitly set a field, a generic null `(::)` can be specified in the mixed list for that field’s value.  
+
+Furthermore, an additional `::` can be included at the end of the mixed list (past the number of message fields).  Such `::` field values are ignored and this can be used to prevent q from changing the message’s mixed list to a simple list, e.g. where all fields have the same q type. (Parsing will return a mixed list without the additional trailing `::` since it is being created directly, outside of q.)
+
+
+### Scalar fields
+
+Scalar fields are represented as q atoms with their type mapping based on the underlying C++ representation.
+
+```txt
+scalar                    C++        kdb+
+----------------------------------------------
+int32, sint32, sfixed32   int32      -6h       
+uint32, fixed32           int32      -6h       
+int64, sint64, sfixed64   int64      -7h       
+uint64, fixed64           int64      -7h       
+double                    double     -9h       
+float                     float      -8h       
+bool                      bool       -1h       
+enum                      int32      -6h       
+string                    string     10h      
+bytes                     string     4h
+```
+
+When parsing from Protobuf to kdb+, for any field which has not been explicitly set in the encoded message, Protobuf will return the default value for that field type which is then populated as usual into the corresponding q element.
+
+Similarly when serializing from q to Protobuf, any q element set to its field-specific default value is equivalent to not explicitly setting that field in the encoded message. It is necessary to pad unspecified message fields with their default value or `::` in q in order to maintain the one-to-one positional mapping between any given message field and its corresponding q element.
+
+
+### Repeated fields
+
+Repeated fields are represented as singularly typed q lists with the underlying q type based on the repeated type:
+
+```txt
+repeated                  C++        kdb+
+-----------------------------------------
+int32, sint32, sfixed32   int32      6h       
+uint32, fixed32           int32      6h       
+int64, sint64, sfixed64   int64      7h       
+uint64, fixed64           int64      7h       
+double                    double     9h       
+float                     float      8h       
+bool                      bool       1h       
+enum                      int32      6h       
+string                    string     0h (of 10h)     
+bytes                     string     0h (of 4h) 
+```
+
+
+### Map fields
+
+Protobuf maps are represented as kdb+ dictionaries with keys and values defined as follows
+
+!!! warning "The Protobuf wire format and map iteration ordering of map items is not deterministic"
+
+    You cannot rely upon it to return a particular dictionary ordering on conversion to q.
+
+
+**Protobuf map keys** can only be integer, boolean or string types and are therefore limited to the following type mappings.
+
+```txt
+map-key                   C++        kdb+
+-----------------------------------------
+int32, sint32, sfixed32   int32      6h        
+uint32, fixed32           int32      6h        
+int64, sint64, sfixed64   int64      7h        
+uint64, fixed64           int64      7h        
+bool                      bool       1h        
+string                    string     11h       
+```
+
+**Protobuf map values** can be any type other than repeated fields or maps and therefore are defined by the following type mapping.
+
+```txt
+map-value                 C++              kdb+
+-----------------------------------------------
+int32, sint32, sfixed32   int32            6h  
+uint32, fixed32           int32            6h  
+int64, sint64, sfixed64   int64            7h  
+uint64, fixed64           int64            7h  
+double                    double           9h  
+float                     float            8h  
+bool                      bool             1h  
+enum                      int32            6h  
+string                    string           0h (of 10h)     
+bytes                     string           0h (of 4h)  
+message                   [message class]  0h  
+```
+
+
+### Oneof fields
+
+Oneof fields are similar to regular fields except all the fields in a oneof share memory, and at most one field can be set at the same time. Setting any member of the oneof automatically clears all the other members.
+
+The q representation of a oneof field is therefore dependent on whether that field is currently the active member of the oneof:
+
+```txt
+Oneof field state  kdb+ representation 
+---------------------------------------
+Set                As per regular field
+Unset              Empty mixed list    
+```
+
+!!! tip "When serializing from kdb+ to Protobuf it is possible to specify values for multiple oneof fields"
+
+    This is valid usage of oneof and does not produce an error; rather the oneof will be set to the value of the last specified field.
+
+
+### `KdbTypeSpecifier` field option
+
+To support the use of the q temporal types and GUIDs which do not have an equivalent representation in Protobuf, a field option extension is provided in `src/kdb_type_specifier.proto` (for compiled in message definitions) and `proto/kdb_type_specified.proto` (for dynamically imported message definitions). This allows a q-specific context to be applied to fields, map-keys and map-values:
+
+```protobuf
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+enum KdbTypeSpecifier {
+    DEFAULT     = 0;
+    TIMESTAMP   = 1;
+    MONTH       = 2;
+    DATE        = 3;
+    DATETIME    = 4;
+    TIMESPAN    = 5;
+    MINUTE      = 6;
+    SECOND      = 7;
+    TIME        = 8;
+    GUID        = 9;
+
+    // Internal use only
+    // Must be at the end since it is used to determine the enum size for lookup arrays
+    KDBTYPE_LEN = 10;
+}
+
+message MapKdbTypeSpecifier {
+    optional KdbTypeSpecifier key_type   = 1;
+    optional KdbTypeSpecifier value_type = 2;
+}
+
+extend google.protobuf.FieldOptions {
+    optional KdbTypeSpecifier    kdb_type        = 756866;
+    optional MapKdbTypeSpecifier map_kdb_type    = 756867;
+}
+```
+
+??? detail "Protobuf versions"
+
+  	For the purpose of compatibility across different versions of Protobuf the above has been defined in proto2. 
+    This definition is equally valid in proto3.
+
+To apply a `KdbTypeSpecifier` to a field, import `kdb_type_specifier.proto` into your `.proto` file, then specify the `KdbTypeSpecifier` field option. 
+For example:
+
+```protobuf
+syntax = "proto3";
+
+import "kdb_type_specifier.proto";
+
+message SpecifierExample {
+    int32           date        = 1 [(kdb_type) = DATE]; // Scalar
+    repeated int32  time        = 2 [(kdb_type) = TIME]; // Repeated
+    map<string, int64>  guid_timespan  = 3 [(map_kdb_type).key_type = GUID,         // Map-key
+                                            (map_kdb_type).value_type = TIMESPAN];  // Map-value
+}
+```
+
+The following is the mapping between the `KdbTypeSpecifier` and associated q types.
+
+```txt
+KdbTypeSpecifier  kdb+ type
+---------------------------
+GUID              2h       
+TIMESTAMP         12h      
+MONTH             13h      
+DATE              14h      
+DATETIME          15h      
+TIMESPAN          16h      
+MINUTE            17h      
+SECOND            18h      
+TIME              19h      
+```
+
+`KdbTypeSpecifier=DEFAULT` is equivalent to the specifier not being present, i.e. the q type is determined from the Proto field type.
+
+The `KdbTypeSpecifier` must be compatible with the defined Proto field type. The following outlines the compatible combinations of types:
+
+```txt
+KdbTypeSpecifier  Compatible Field Type                   
+----------------------------------------------------------
+GUID              string, bytes                           
+TIMESTAMP         int64, sint64, sfixed64, uint64, fixed64
+MONTH             int32, sint32, sfixed32, uint32, fixed32
+DATE              int32, sint32, sfixed32, uint32, fixed32
+DATETIME          double                                  
+TIMESPAN          int64, sint64, sfixed64, uint64, fixed64
+MINUTE            int32, sint32, sfixed32, uint32, fixed32
+SECOND            int32, sint32, sfixed32, uint32, fixed32
+TIME              int32, sint32, sfixed32, uint32, fixed32
+```
+
+
+## Type checking
+
+When serializing from q to Protobuf, the q structure must conform to the mappings above with respect to that particular message definition. This is important both in terms of the type of each message field (scalar, repeated, map, etc.) and the Proto type specified to represent that field (int32, double, string, etc.)
+
+The interface will type-check each field as appropriate and return an error if a mismatch is detected detailing:
+
+1.  The type of failure
+2.  The message/field where it occurred
+3.  The expected q type
+4.  The received q type
+
+For example:
+
+```q
+q).protobufkdb.displayMessageSchema[`ScalarExample]
+message ScalarExample {
+  int32 scalar_int32 = 1;
+  double scalar_double = 2;
+  string scalar_string = 3;
+}
+
+// Correct function invocation
+q)array:.protobufkdb.serializeArrayFromList[`ScalarExample;(12i;55f;"str")]
+
+q)array:.protobufkdb.serializeArrayFromList[`ScalarExample;(12i;55f)]
+'Incorrect number of fields, message: 'ScalarExample', expected: 3, received: 2
+  [0]  array:.protobufkdb.serializeArrayFromList[`ScalarExample;(12i;55f)]
+             ^
+
+q)array:.protobufkdb.serializeArrayFromList[`ScalarExample;(12j;55f;"str")]
+'Invalid scalar type, field: 'ScalarExample.scalar_int32', expected: -6, received: -7
+  [0]  array:.protobufkdb.serializeArrayFromList[`ScalarExample;(12j;55f;"str")]
+             ^
+
+q)array:.protobufkdb.serializeArrayFromList[`ScalarExample;(enlist 12i;55f;"str")]
+'Invalid scalar type, field: 'ScalarExample.scalar_int32', expected: -6, received: 6
+  [0]  array:.protobufkdb.serializeArrayFromList[`ScalarExample;(enlist 12i;55f;"str")]
+             ^
+```
+
+
+## Representing messages as q dictionaries
+
+As described above, protobufkdb represents a message in q as a mixed list of field values in field-positional order. This more closely ties in with how protobuf serializes messages, and is recommended for performance reasons.
+
+However, you may prefer the q mapping for messages to be a dictionary from symbol field names to a mixed list of field values, similarly to how JSON is represented.  This style is supported through separate APIs for both the parsing and serialization functions.
+
+Rather than the field-positional order:
+
+-   Each field name is looked up in the message and its corresponding field value applied
+-   Any message fields without a field name/value pair in the dictionary are not explicitly set
+-   Where is field value is set to the generic null (`::`) that field name/value pair is ignored
+-   Where a field name is specified (and its value is not `::`) but that field is not present is the message, a type-check error is returned
+
+In addition the dictionary style is used recursively when fields contain other messages:
+
+```txt
+field type            kdb+ structure        
+------------------------------------------------------------------------------------
+Sub-message           Field name dictionary            
+Repeated sub-message  List of field name dictionaries or a flip table   
+Map to message        Map-value is a list of field name dictionaries or a flip table       
+```
+
+All other field types use the same q mapping for the field value as is used by the mixed-list message style.
+

--- a/docs/protobuf-types.md
+++ b/docs/protobuf-types.md
@@ -1,18 +1,7 @@
----
-title: Datatype mappings | Protobuf | Interfaces | Documentation for kdb+ and q
-author: Conor McCarthy
-description: Datatype mappings between kdb+ and Protobuf
-date: September 2020
----
 # Type mapping between kdb+ and Protobuf 
 
-:fontawesome-brands-github:
-[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
 
-
-
-
-We describe how q numeric and string types are represented in Protobuf, how Protobuf structures are mapped to q.
+_How q numeric and string types are represented in Protobuf, how Protobuf structures are mapped to q_
 
 ## Protobuf/q mapping
 
@@ -101,9 +90,9 @@ bytes                     string     0h (of 4h)
 
 Protobuf maps are represented as kdb+ dictionaries with keys and values defined as follows
 
-!!! warning "The Protobuf wire format and map iteration ordering of map items is not deterministic"
-
-    You cannot rely upon it to return a particular dictionary ordering on conversion to q.
+> :warning: **The Protobuf wire format and map iteration ordering of map items is not deterministic**
+> 
+> You cannot rely upon it to return a particular dictionary ordering on conversion to q.
 
 
 **Protobuf map keys** can only be integer, boolean or string types and are therefore limited to the following type mappings.
@@ -151,9 +140,9 @@ Set                As per regular field
 Unset              Empty mixed list    
 ```
 
-!!! tip "When serializing from kdb+ to Protobuf it is possible to specify values for multiple oneof fields"
-
-    This is valid usage of oneof and does not produce an error; rather the oneof will be set to the value of the last specified field.
+> Tip: When serializing from kdb+ to Protobuf it is possible to specify values for multiple oneof fields
+>
+> This is valid usage of oneof and does not produce an error; rather the oneof will be set to the value of the last specified field.
 
 
 ### `KdbTypeSpecifier` field option
@@ -193,10 +182,10 @@ extend google.protobuf.FieldOptions {
 }
 ```
 
-??? detail "Protobuf versions"
-
-  	For the purpose of compatibility across different versions of Protobuf the above has been defined in proto2. 
-    This definition is equally valid in proto3.
+> Protobuf versions
+> 
+> For the purpose of compatibility across different versions of Protobuf the above has been defined in proto2. 
+> This definition is equally valid in proto3.
 
 To apply a `KdbTypeSpecifier` to a field, import `kdb_type_specifier.proto` into your `.proto` file, then specify the `KdbTypeSpecifier` field option. 
 For example:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,660 @@
+---
+title: Function reference | Protobuf | Interfaces | Documentation for kdb+ and q
+description: Protobuf/Protocol Buffers kdb+ interface function reference
+---
+# Protobuf/Protocol Buffers function reference
+
+
+
+_Functions exposed in the `.protobufkdb` namespace allow you to generate and parse Protobuf messages_
+
+:fontawesome-brands-github:
+[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
+
+<div markdown="1" class="typewriter">
+.protobufkdb.   **Protobuf/Protocol Buffers interface**
+
+
+Library information
+  [version](#protobufkdbversion)                         Return the libprotobuf version as an integer
+  [versionStr](#protobufkdbversionstr)                      Return the libprotobuf version as a string
+
+Import schema
+  [addProtoImportPath](#protobufkdbaddprotoimportpath)              Add a path from which to import proto schema files
+  [importProtoFile](#protobufkdbimportprotofile)                 Import a proto schema file
+  [listImportedMessageTypes](#protobufkdblistimportedmessagetypes)        List successfully imported message schemas
+
+Inspect schema
+  [displayMessageSchema](#protobufkdbdisplaymessageschema)            Display the schema definition of the message
+  [getMessageFields](#protobufkdbgetmessagefields)                Get the list of message fields
+
+Serialize/parse using list
+  [serializeArrayFromList](#protobufkdbserializearrayfromlist)          Serialize from a kdb+ mixed list object to a string
+  [serializeArrayArenaFromList](#protobufkdbserializearrayarenafromlist)     Serialize from a kdb+ mixed list object to a string, 
+                                  using a Google Arena for the intermediate message
+  [parseArrayToList](#protobufkdbparsearraytolist)                Parse from a string to a kdb+ mixed list object
+  [parseArrayArenaToList](#protobufkdbparsearrayarenatolist)           Parse from a string to a kdb+ mixed list object, using 
+                                  a Google Arena for the intermediate message
+
+Serialize/parse using dictionary
+  [serializeArrayFromDict](#protobufkdbserializearrayfromdict)          Serialize from a kdb+ dictionary to a string
+  [serializeArrayArenaFromDict](#protobufkdbserializearrayarenafromdict)     Serialize from a kdb+ dictionary to a string, using 
+                                  a Google Arena for the intermediate message
+  [parseArrayToDict](#protobufkdbparsearraytodict)                Parse from a string to a kdb+ dictionary
+  [parseArrayArenaToDict](#protobufkdbparsearrayarenatodict)           Parse from a string to a kdb+ dictionary, using 
+                                  a Google Arena for the intermediate message
+
+Save/load using list
+  [saveMessageFromList](#protobufkdbsavemessagefromlist)             Serialize from a kdb+ mixed list object to a file
+  [loadMessageToList](#protobufkdbloadmessagetolist)               Parse from a file to a kdb+ mixed list object
+
+Save/load using dictionary
+  [saveMessageFromDict](#protobufkdbsavemessagefromdict)             Serialize from a kdb+ dictionary to a file
+  [loadMessageToDict](#protobufkdbloadmessagetodict)               Parse from a file to a kdb+ dictionary
+
+Debugging
+  [parseArrayDebug](#protobufkdbparsearraydebug)                 Parse from a string and display debugging
+  [loadMessageDebug](#protobufkdbloadmessagedebug)                Parse from a file and display debugging
+
+
+
+</div>
+
+
+??? detail "Message types"
+
+    Where a function takes a `message_type` parameter to specify the name of the message to be be processed, the interface first looks for that message type in the compiled messages. 
+    
+    If that fails it then searches the imported message definitions.  Only if the message type is not found in either is an error returned.
+
+
+## `addProtoImportPath`
+
+_Add an import path_
+
+
+```txt
+.protobufkdb.addProtoImportPath[import_path]
+```
+
+Where `import_path` is a path (absolute or relative) as a string
+
+1.  adds it as a path to be searched when dynamically importing `.proto` file definitions
+1.  returns generic null
+
+Establishes virtual file system mappings such that the import locations appear under the current directory, similar to the `PATH` environment variable.  Can be called more than once to specify multiple import locations.
+
+Where your `.proto` file definition imports other `.proto` files (including recursively), these must also be available on the import paths.  
+
+??? detail "Importing Google's .proto files"
+
+    The regular `.proto` files provided by Google are available in the install package (either when downloaded or built from source) under the `proto` subdirectory.
+    
+    For examples `kdb_type_specifier.proto` imports `google/protobuf/descriptor.proto` which is available in the `proto` subdirectory.
+
+```q
+// successful execution
+q).protobufkdb.addProtoImportPath["../proto"]
+
+// incorrect data format provided as input
+q).protobufkdb.addProtoImportPath[enlist 1f]
+'"Specify import path"
+```
+
+
+## `displayMessageSchema`
+
+_Display the Proto schema of a specified message_
+
+```txt
+.protobufkdb.displayMessageSchema[message_type]
+```
+
+Where `message_type` is the name of a message type as a string, 
+
+1.  prints schema format to stdout 
+1.  returns generic null
+
+`message_type` must match a message name in its `.proto` definition.
+
+??? warning "For use only in debugging"
+
+    The schema is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
+
+```q
+q).protobufkdb.displayMessageSchema[`ScalarExampleDynamic]
+message ScalarExampleDynamic {
+  int32 scalar_int32 = 1;
+  double scalar_double = 2;
+  string scalar_string = 3;
+}
+```
+
+
+## `getMessageFields`
+
+_Get the list of message fields_
+
+```txt
+.protobufkdb.getMessageFields[message_type]
+```
+
+Where `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+
+returns the symbol list of message fields in the order they are declared in the message definition.
+
+```q
+q).protobufkdb.getMessageFields[`ScalarExampleDynamic]
+`scalar_int32`scalar_double`scalar_string
+```
+
+
+## `importProtoFile`
+
+_Import a `.proto` file definition_
+
+
+```txt
+.protobufkdb.importProtoFile[filename]
+```
+
+Where `filename` is the name of a `.proto` file as a string
+
+1.  dynamically imports the file definition into the interface
+1.  returns generic null
+
+Success allows the message types defined in the file to be parsed and serialized by the interface.
+
+Signalled errors contain errors and warnings which occurred in parsing the file.
+
+!!! warning "The filename may not include a path." 
+
+    Define directory search locations beforehand with `.protobufkdb.addProtoImportPath`.
+
+```q
+// successful function invocation
+q).protobufkdb.importProtoFile["examples_dynamic.proto"]
+
+// proto file does not exist
+q).protobufkdb.importProtoFile["not_a_file.proto"]
+'Error: not_a_file.proto:-1:0: File not found.
+
+  [0]  .protobufkdb.importProtoFile["not_a_file.proto"]
+       ^
+```
+
+
+## `listImportedMessageTypes`
+
+_List imported message types_
+
+```txt
+.protobufkdb.listImportedMessageTypes[]
+```
+
+Returns successfully imported message types as a symbol list.
+
+!!! detail "The list does not contain message types compiled into the interface."
+
+```q
+q).protobufkdb.listImportedMessageTypes[]
+`ScalarExampleDynamic`RepeatedExampleDynamic`SubMessageExampleDynamic`MapExam..
+```
+
+
+## `loadMessageDebug`
+
+_Parse from a Protobuf message file and display the debugging_
+
+```txt
+.protobufkdb.loadMessageDebug[message_type;file_name]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `file_name` is the name of a file (string or symbol)
+
+the function
+
+1.  prints debugging information to stdout 
+1.  returns generic null
+
+??? warning "For use only in debugging"
+
+    The debugging is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
+
+```q
+q)data
+1    2
+10   20
+"s1" "s2"
+q).protobufkdb.saveMessageFromList[`RepeatedExampleDynamic;`trivial_message_file;data]
+q).protobufkdb.loadMessageDebug[`RepeatedExampleDynamic;`trivial_message_file]
+rep_int32: 1
+rep_int32: 2
+rep_double: 10
+rep_double: 20
+rep_string: "s1"
+rep_string: "s2"
+```
+
+
+## `loadMessageToDict`
+
+_Parse from a Protobuf message file to a kdb+ dictionary_
+
+```txt
+.protobufkdb.loadMessageToDict[message_type;file_name]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `file_name` is the name of a file (string or symbol)
+
+returns a dictionary from field name symbols to field values parsed from `file_name`.
+
+```q
+q)data
+rep_int32 | 1    2
+rep_double| 10   20
+rep_string| "s1" "s2"
+q).protobufkdb.saveMessageFromDict[`RepeatedExampleDynamic;`trivial_message_file;data]
+q).protobufkdb.loadMessageToDict[`RepeatedExampleDynamic;`trivial_message_file]
+rep_int32 | 1    2
+rep_double| 10   20
+rep_string| "s1" "s2"
+```
+
+
+## `loadMessageToList`
+
+_Parse from a Protobuf message file to a kdb+ mixed list object_
+
+```txt
+.protobufkdb.loadMessageToList[message_type;file_name]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `file_name` is the name of a file (string or symbol)
+
+returns a kdb+ mixed list object parsed from `file_name`.
+
+```q
+q)data
+1    2
+10   20
+"s1" "s2"
+q).protobufkdb.saveMessageFromList[`RepeatedExampleDynamic;`trivial_message_file;data]
+q).protobufkdb.loadMessageToList[`RepeatedExampleDynamic;`trivial_message_file]
+1    2
+10   20
+"s1" "s2"
+```
+
+
+## `parseArrayArenaToDict`
+
+_Parse from a Protobuf message string to a kdb+ dictionary, using a Google Arena for the intermediate message_
+
+```txt
+.protobufkdb.parseArrayArenaToDict[message_type;char_array]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `char_array` is the serialized Protobuf message (string)
+
+the function
+
+1.  parses the string as a Protobuf message, which it creates on a Google Arena
+2.  returns the message as a kdb+ dictionary from field name symbols to field values
+
+!!! detail "Identical to `parseArrayToDict` except the intermediate Protobuf message is created on a Google Arena"
+
+    Can improve memory allocation performance for large messages with deep repeated fields/map.
+    
+    :fontawesome-brands-google:
+    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+
+```q
+q)fields:.protobufkdb.getMessageFields[`RepeatedExampleDynamic]
+q)data:fields!(1 2i;10 20f;("s1";"s2"))
+q)array:.protobufkdb.serializeArrayFromDict[`RepeatedExampleDynamic;data]
+q)array
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+q).protobufkdb.parseArrayArenaToDict[`RepeatedExampleDynamic;array]
+rep_int32 | 1    2
+rep_double| 10   20
+rep_string| "s1" "s2"
+```
+
+
+## `parseArrayArenaToList`
+
+_Parse from a Protobuf message string to a kdb+ mixed list object, using a Google Arena for the intermediate message_
+
+```txt
+.protobufkdb.parseArrayArenaToList[message_type;char_array]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `char_array` is the serialized Protobuf message (string)
+
+the function
+
+1.  parses the string as a Protobuf message, which it creates on a Google Arena
+2.  returns the message as a kdb+ mixed list object
+
+!!! detail "Identical to `parseArrayToList` except the intermediate Protobuf message is created on a Google Arena"
+
+    Can improve memory allocation performance for large messages with deep repeated fields/map.
+    
+    :fontawesome-brands-google:
+    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+
+```q
+q)data:(1 2i;10 20f;("s1";"s2"))
+q)array:.protobufkdb.serializeArrayFromList[`RepeatedExampleDynamic;data]
+q)array
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+q).protobufkdb.parseArrayArenaToList[`RepeatedExampleDynamic;array]
+1    2
+10   20
+"s1" "s2"
+```
+
+
+## `parseArrayDebug`
+
+_Parse from a Protobuf message string and display the debugging_
+
+```txt
+.protobufkdb.parseArrayDebug[message_type;char_array]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `char_array` is the serialized Protobuf message (string)
+
+the function
+
+1.  prints debugging information to stdout 
+1.  returns generic null
+
+??? warning "For use only in debugging"
+
+    The debugging is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
+
+```q
+q)data:(1 2i;10 20f;("s1";"s2"))
+q)array:.protobufkdb.serializeArrayFromList[`RepeatedExampleDynamic;data]
+q).protobufkdb.parseArrayDebug[`RepeatedExampleDynamic;array]
+rep_int32: 1
+rep_int32: 2
+rep_double: 10
+rep_double: 20
+rep_string: "s1"
+rep_string: "s2"
+```
+
+
+## `parseArrayToDict`
+
+_Parse from a Protobuf message string to a kdb+ dictionary_
+
+```txt
+.protobufkdb.parseArrayToDict[message_type;char_array]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `char_array` is the serialized Protobuf message (string)
+
+returns the message as a kdb+ dictionary from field name symbols to field values.
+
+```q
+q)fields:.protobufkdb.getMessageFields[`RepeatedExampleDynamic]
+q)data:fields!(1 2i;10 20f;("s1";"s2"))
+q)array:.protobufkdb.serializeArrayFromDict[`RepeatedExampleDynamic;data]
+q)array
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+q).protobufkdb.parseArrayToDict[`RepeatedExampleDynamic;array]
+rep_int32 | 1    2
+rep_double| 10   20
+rep_string| "s1" "s2"
+```
+
+
+## `parseArrayToList`
+
+_Parse from a Protobuf message string to a kdb+ mixed list object_
+
+```txt
+.protobufkdb.parseArrayToList[message_type;char_array]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `char_array` is the serialized Protobuf message (string)
+
+returns the message as a kdb+ mixed list object.
+
+```q
+q)data:(1 2i;10 20f;("s1";"s2"))
+q)array:.protobufkdb.serializeArrayFromList[`RepeatedExampleDynamic;data]
+q)array
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+q).protobufkdb.parseArrayToList[`RepeatedExampleDynamic;array]
+1    2
+10   20
+"s1" "s2"
+```
+
+
+## `saveMessageFromDict`
+
+_Serialize from a kdb+ dictionary to a Protobuf message file_
+
+```txt
+.protobufkdb.saveMessageFromDict[message_type;file_name;msg_in]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `file_name` is the name of a file (string or symbol)
+-   `msg_in` is a kdb+ dictionary from field name symbols to field values
+
+the function 
+
+1.  converts `msg_in` to a Protobuf message of `message_type`, serializes it, and writes it to `file_name`
+2.  returns generic null
+
+```q
+q)data
+rep_int32 | 1    2
+rep_double| 10   20
+rep_string| "s1" "s2"
+q).protobufkdb.saveMessageFromDict[`RepeatedExampleDynamic;`trivial_message_file;data]
+```
+
+
+## `saveMessageFromList`
+
+_Serialize from a kdb+ mixed list object to a Protobuf message file_
+
+```txt
+.protobufkdb.saveMessageFromList[message_type;file_name;msg_in]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `file_name` is the name of a file (string or symbol)
+-   `msg_in` is a kdb+ mixed list object 
+
+the function 
+
+1.  converts `msg_in` to a Protobuf message of `message_type`, serializes it, and writes it to `file_name`
+2.  returns generic null
+
+```q
+q)data
+1    2
+10   20
+"s1" "s2"
+q).protobufkdb.saveMessageFromList[`RepeatedExampleDynamic;`trivial_message_file;data]
+```
+
+
+## `serializeArrayArenaFromDict`
+
+_Serialize from a kdb+ dictionary to a Protobuf message string, using a Google Arena for the intermediate message_
+
+```txt
+.protobufkdb.serializeArrayArenaFromDict[message_type;msg_in]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `msg_in` is a kdb+ dictionary from field name symbols to field values
+
+the function
+
+1.  serializes `msg_in` as a Protobuf message and creates it on a Google Arena
+2.  returns the serialized Protobuf message as a string
+
+!!! detail "Identical to `serializeArrayFromDict` except the intermediate Protobuf message is created on a Google Arena"
+
+    Can improve memory allocation performance for large messages with deep repeated fields/map.
+    
+    :fontawesome-brands-google:
+    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+
+```q
+q)fields:.protobufkdb.getMessageFields[`RepeatedExampleDynamic]
+q)data:fields!(1 2i;10 20f;("s1";"s2"))
+q).protobufkdb.serializeArrayArenaFromDict[`RepeatedExampleDynamic;data]
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+```
+
+
+## `serializeArrayArenaFromList`
+
+_Serialize from a kdb+ mixed list object to a Protobuf message string, using a Google Arena for the intermediate message_
+
+```txt
+.protobufkdb.serializeArrayArenaFromList[message_type;msg_in]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `msg_in` is a kdb+ mixed list object 
+
+the function
+
+1.  serializes `msg_in` as a Protobuf message and creates it on a Google Arena
+2.  returns the serialized Protobuf message as a string
+
+!!! detail "Identical to `serializeArrayFromList` except the Protobuf message is created on a Google Arena"
+
+    Can improve memory allocation performance for large messages with deep repeated fields/map.
+    
+    :fontawesome-brands-google:
+    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+
+```q
+q)data:(1 2i;10 20f;("s1";"s2"))
+q).protobufkdb.serializeArrayArenaFromList[`RepeatedExampleDynamic;data]
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+```
+
+
+## `serializeArrayFromDict`
+
+_Serialize from a kdb+ dictionary to a Protobuf message string_
+
+```txt
+.protobufkdb.serializeArrayFromDict[message_type; msg_in]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `msg_in` is a kdb+ dictionary from field name symbols to field values
+
+returns the serialized Protobuf message as a string.
+
+```q
+q)fields:.protobufkdb.getMessageFields[`RepeatedExampleDynamic]
+q)data:fields!(1 2i;10 20f;("s1";"s2"))
+q).protobufkdb.serializeArrayFromDict[`RepeatedExampleDynamic;data]
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+```
+
+
+## `serializeArrayFromList`
+
+_Serialize from a kdb+ mixed list object to a Protobuf message string_
+
+```txt
+.protobufkdb.serializeArrayFromList[message_type; msg_in]
+```
+
+Where
+
+-   `message_type` is a message type (string or symbol) matching a message name in the `.proto` definition
+-   `msg_in` is a kdb+ mixed list object 
+
+returns the serialized Protobuf message as a string.
+
+```q
+q)data:(1 2i;10 20f;("s1";"s2"))
+q).protobufkdb.serializeArrayFromList[`RepeatedExampleDynamic;data]
+"\n\002\001\002\022\020\000\000\000\000\000\000$@\000\000\000\000\000\0004@\0..
+```
+
+
+## `version`
+
+_Library version (integer) used by the interface_
+
+```txt
+.protobufkdb.version[]
+```
+
+returns the version of the `libprotobuf` shared object used by the interface, as an integer.
+
+```q
+q).protobufkdb.version[]
+3012003i
+```
+
+
+## `versionStr`
+
+_Library version (string) used by the interface_
+
+```txt
+.protobufkdb.versionStr[]
+```
+
+returns the version of the `libprotobuf` shared object used by the interface, as a string.
+
+```q
+q).protobufkdb.versionStr[]
+"libprotobuf v3.12.3"
+```
+

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,71 +1,54 @@
----
-title: Function reference | Protobuf | Interfaces | Documentation for kdb+ and q
-description: Protobuf/Protocol Buffers kdb+ interface function reference
----
 # Protobuf/Protocol Buffers function reference
 
 
 
 _Functions exposed in the `.protobufkdb` namespace allow you to generate and parse Protobuf messages_
 
-:fontawesome-brands-github:
-[KxSystems/protobufkdb](https://github.com/KxSystems/protobufkdb)
+`.protobufkdb.`   **Protobuf/Protocol Buffers interface**
 
-<div markdown="1" class="typewriter">
-.protobufkdb.   **Protobuf/Protocol Buffers interface**
+Library information<br>
+[`version`](#protobufkdbversion)                         Return the libprotobuf version as an integer<br>
+[`versionStr`](#protobufkdbversionstr)                      Return the libprotobuf version as a string
 
+Import schema<br>
+[`addProtoImportPath`](#protobufkdbaddprotoimportpath)              Add a path from which to import proto schema files<br>
+[`importProtoFile`](#protobufkdbimportprotofile)                 Import a proto schema file<br>
+[`listImportedMessageTypes`](#protobufkdblistimportedmessagetypes)        List successfully imported message schemas
 
-Library information
-  [version](#protobufkdbversion)                         Return the libprotobuf version as an integer
-  [versionStr](#protobufkdbversionstr)                      Return the libprotobuf version as a string
+Inspect schema<br>
+[`displayMessageSchema`](#protobufkdbdisplaymessageschema)            Display the schema definition of the message<br>
+[`getMessageFields`](#protobufkdbgetmessagefields)                Get the list of message fields
 
-Import schema
-  [addProtoImportPath](#protobufkdbaddprotoimportpath)              Add a path from which to import proto schema files
-  [importProtoFile](#protobufkdbimportprotofile)                 Import a proto schema file
-  [listImportedMessageTypes](#protobufkdblistimportedmessagetypes)        List successfully imported message schemas
+Serialize/parse using list<br>
+[`serializeArrayFromList`](#protobufkdbserializearrayfromlist)          Serialize from a kdb+ mixed list object to a string<br>
+[`serializeArrayArenaFromList`](#protobufkdbserializearrayarenafromlist)     Serialize from a kdb+ mixed list object to a string, using a Google Arena for the intermediate message<br>
+[`parseArrayToList`](#protobufkdbparsearraytolist)                Parse from a string to a kdb+ mixed list object<br>
+[`parseArrayArenaToList`](#protobufkdbparsearrayarenatolist)           Parse from a string to a kdb+ mixed list object, using a Google Arena for the intermediate message
 
-Inspect schema
-  [displayMessageSchema](#protobufkdbdisplaymessageschema)            Display the schema definition of the message
-  [getMessageFields](#protobufkdbgetmessagefields)                Get the list of message fields
+Serialize/parse using dictionary<br>
+[`serializeArrayFromDict`](#protobufkdbserializearrayfromdict)          Serialize from a kdb+ dictionary to a string<br>
+[`serializeArrayArenaFromDict`](#protobufkdbserializearrayarenafromdict)     Serialize from a kdb+ dictionary to a string, using a Google Arena for the intermediate message<br>
+[`parseArrayToDict`](#protobufkdbparsearraytodict)                Parse from a string to a kdb+ dictionary<br>
+[`parseArrayArenaToDict`](#protobufkdbparsearrayarenatodict)           Parse from a string to a kdb+ dictionary, using a Google Arena for the intermediate message
 
-Serialize/parse using list
-  [serializeArrayFromList](#protobufkdbserializearrayfromlist)          Serialize from a kdb+ mixed list object to a string
-  [serializeArrayArenaFromList](#protobufkdbserializearrayarenafromlist)     Serialize from a kdb+ mixed list object to a string, 
-                                  using a Google Arena for the intermediate message
-  [parseArrayToList](#protobufkdbparsearraytolist)                Parse from a string to a kdb+ mixed list object
-  [parseArrayArenaToList](#protobufkdbparsearrayarenatolist)           Parse from a string to a kdb+ mixed list object, using 
-                                  a Google Arena for the intermediate message
+Save/load using list<br>
+[`saveMessageFromList`](#protobufkdbsavemessagefromlist)             Serialize from a kdb+ mixed list object to a file<br>
+[`loadMessageToList`](#protobufkdbloadmessagetolist)               Parse from a file to a kdb+ mixed list object
 
-Serialize/parse using dictionary
-  [serializeArrayFromDict](#protobufkdbserializearrayfromdict)          Serialize from a kdb+ dictionary to a string
-  [serializeArrayArenaFromDict](#protobufkdbserializearrayarenafromdict)     Serialize from a kdb+ dictionary to a string, using 
-                                  a Google Arena for the intermediate message
-  [parseArrayToDict](#protobufkdbparsearraytodict)                Parse from a string to a kdb+ dictionary
-  [parseArrayArenaToDict](#protobufkdbparsearrayarenatodict)           Parse from a string to a kdb+ dictionary, using 
-                                  a Google Arena for the intermediate message
+Save/load using dictionary<br>
+[`saveMessageFromDict`](#protobufkdbsavemessagefromdict)             Serialize from a kdb+ dictionary to a file<br>
+[`loadMessageToDict`](#protobufkdbloadmessagetodict)               Parse from a file to a kdb+ dictionary
 
-Save/load using list
-  [saveMessageFromList](#protobufkdbsavemessagefromlist)             Serialize from a kdb+ mixed list object to a file
-  [loadMessageToList](#protobufkdbloadmessagetolist)               Parse from a file to a kdb+ mixed list object
-
-Save/load using dictionary
-  [saveMessageFromDict](#protobufkdbsavemessagefromdict)             Serialize from a kdb+ dictionary to a file
-  [loadMessageToDict](#protobufkdbloadmessagetodict)               Parse from a file to a kdb+ dictionary
-
-Debugging
-  [parseArrayDebug](#protobufkdbparsearraydebug)                 Parse from a string and display debugging
-  [loadMessageDebug](#protobufkdbloadmessagedebug)                Parse from a file and display debugging
+Debugging<br>
+[`parseArrayDebug`](#protobufkdbparsearraydebug)                 Parse from a string and display debugging<br>
+[`loadMessageDebug`](#protobufkdbloadmessagedebug)                Parse from a file and display debugging
 
 
-
-</div>
-
-
-??? detail "Message types"
-
-    Where a function takes a `message_type` parameter to specify the name of the message to be be processed, the interface first looks for that message type in the compiled messages. 
-    
-    If that fails it then searches the imported message definitions.  Only if the message type is not found in either is an error returned.
+> Message types
+> 
+> Where a function takes a `message_type` parameter to specify the name of the message to be be processed, the interface first looks for that message type in the compiled messages. 
+> 
+> If that fails it then searches the imported message definitions.  Only if the message type is not found in either is an error returned.
 
 
 ## `addProtoImportPath`
@@ -82,15 +65,15 @@ Where `import_path` is a path (absolute or relative) as a string
 1.  adds it as a path to be searched when dynamically importing `.proto` file definitions
 1.  returns generic null
 
-Establishes virtual file system mappings such that the import locations appear under the current directory, similar to the `PATH` environment variable.  Can be called more than once to specify multiple import locations.
+establishes virtual file system mappings such that the import locations appear under the current directory, similar to the `PATH` environment variable.  Can be called more than once to specify multiple import locations.
 
 Where your `.proto` file definition imports other `.proto` files (including recursively), these must also be available on the import paths.  
 
-??? detail "Importing Google's .proto files"
-
-    The regular `.proto` files provided by Google are available in the install package (either when downloaded or built from source) under the `proto` subdirectory.
-    
-    For examples `kdb_type_specifier.proto` imports `google/protobuf/descriptor.proto` which is available in the `proto` subdirectory.
+> Importing Google's `.proto` files
+> 
+> The regular `.proto` files provided by Google are available in the install package (either when downloaded or built from source) under the `proto` subdirectory.
+>     
+> For examples `kdb_type_specifier.proto` imports `google/protobuf/descriptor.proto` which is available in the `proto` subdirectory.
 
 ```q
 // successful execution
@@ -117,9 +100,9 @@ Where `message_type` is the name of a message type as a string,
 
 `message_type` must match a message name in its `.proto` definition.
 
-??? warning "For use only in debugging"
-
-    The schema is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
+> :warning: **For use only in debugging**
+> 
+> The schema is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
 
 ```q
 q).protobufkdb.displayMessageSchema[`ScalarExampleDynamic]
@@ -167,9 +150,9 @@ Success allows the message types defined in the file to be parsed and serialized
 
 Signalled errors contain errors and warnings which occurred in parsing the file.
 
-!!! warning "The filename may not include a path." 
+:warning: **The filename may not include a path.**
 
-    Define directory search locations beforehand with `.protobufkdb.addProtoImportPath`.
+Define directory search locations beforehand with `.protobufkdb.addProtoImportPath`.
 
 ```q
 // successful function invocation
@@ -194,7 +177,7 @@ _List imported message types_
 
 Returns successfully imported message types as a symbol list.
 
-!!! detail "The list does not contain message types compiled into the interface."
+> The list does not contain message types compiled into the interface.
 
 ```q
 q).protobufkdb.listImportedMessageTypes[]
@@ -220,9 +203,9 @@ the function
 1.  prints debugging information to stdout 
 1.  returns generic null
 
-??? warning "For use only in debugging"
-
-    The debugging is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
+> :warning: **For use only in debugging**
+> 
+> The debugging is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
 
 ```q
 q)data
@@ -314,12 +297,11 @@ the function
 1.  parses the string as a Protobuf message, which it creates on a Google Arena
 2.  returns the message as a kdb+ dictionary from field name symbols to field values
 
-!!! detail "Identical to `parseArrayToDict` except the intermediate Protobuf message is created on a Google Arena"
-
-    Can improve memory allocation performance for large messages with deep repeated fields/map.
-    
-    :fontawesome-brands-google:
-    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+> **Identical to `parseArrayToDict` except the intermediate Protobuf message is created on a Google Arena**
+> 
+> Can improve memory allocation performance for large messages with deep repeated fields/map.
+>     
+> [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
 
 ```q
 q)fields:.protobufkdb.getMessageFields[`RepeatedExampleDynamic]
@@ -352,12 +334,11 @@ the function
 1.  parses the string as a Protobuf message, which it creates on a Google Arena
 2.  returns the message as a kdb+ mixed list object
 
-!!! detail "Identical to `parseArrayToList` except the intermediate Protobuf message is created on a Google Arena"
-
-    Can improve memory allocation performance for large messages with deep repeated fields/map.
-    
-    :fontawesome-brands-google:
-    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+> **Identical to `parseArrayToList` except the intermediate Protobuf message is created on a Google Arena**
+> 
+> Can improve memory allocation performance for large messages with deep repeated fields/map.
+>     
+> [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
 
 ```q
 q)data:(1 2i;10 20f;("s1";"s2"))
@@ -389,9 +370,9 @@ the function
 1.  prints debugging information to stdout 
 1.  returns generic null
 
-??? warning "For use only in debugging"
-
-    The debugging is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
+> :warning: **For use only in debugging**
+> 
+> The debugging is generated by the libprotobuf `DebugString()` functionality and displayed on stdout to preserve formatting and indentation.
 
 ```q
 q)data:(1 2i;10 20f;("s1";"s2"))
@@ -535,12 +516,11 @@ the function
 1.  serializes `msg_in` as a Protobuf message and creates it on a Google Arena
 2.  returns the serialized Protobuf message as a string
 
-!!! detail "Identical to `serializeArrayFromDict` except the intermediate Protobuf message is created on a Google Arena"
-
-    Can improve memory allocation performance for large messages with deep repeated fields/map.
-    
-    :fontawesome-brands-google:
-    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+> **Identical to `serializeArrayFromDict` except the intermediate Protobuf message is created on a Google Arena**
+> 
+> Can improve memory allocation performance for large messages with deep repeated fields/map.
+> 
+> [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
 
 ```q
 q)fields:.protobufkdb.getMessageFields[`RepeatedExampleDynamic]
@@ -568,12 +548,11 @@ the function
 1.  serializes `msg_in` as a Protobuf message and creates it on a Google Arena
 2.  returns the serialized Protobuf message as a string
 
-!!! detail "Identical to `serializeArrayFromList` except the Protobuf message is created on a Google Arena"
-
-    Can improve memory allocation performance for large messages with deep repeated fields/map.
-    
-    :fontawesome-brands-google:
-    [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
+> **Identical to `serializeArrayFromList` except the Protobuf message is created on a Google Arena**
+> 
+> Can improve memory allocation performance for large messages with deep repeated fields/map.
+>     
+> [Google Arenas](https://developers.google.com/protocol-buffers/docs/reference/arenas)
 
 ```q
 q)data:(1 2i;10 20f;("s1";"s2"))

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,10 +2,10 @@
 
 Each script contained within this folder deals with a different aspect of the interface and aims to showcases a particular section of the protobufkdb library. The use cases highlighted below are:
 
-1. Messages added to a session at compile time
-2. Messages dynamically loaded into the session
+1.  Messages added to a session at compile time
+2.  Messages dynamically loaded into the session
 
-More basic example workflows are highlighted in the documentation for this interface [here](https://code.kx.com/q/interfaces/protobuf/examples).
+More basic example workflows are highlighted in the [exaples documentation](../docs/examples.md).
 
 ## Compiled in messages
 


### PR DESCRIPTION
⚠️ *The interface docs will leave code.kx.com on 2023.03.01**

Imported docs from code.kx.com/q/interfaces/protobuf, translated to GFM; switched links.