### PR TITLE
travis stopped supporting osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jobs:
     os: linux
   - dist: bionic
     os: linux
-  - os: osx
   - os: windows
 language: c
 compiler: gcc


### PR DESCRIPTION
travis-ci "Starting April 1st, 2025, OSx/macOS builds will no longer be supported due to the end-of-life (EOL) of VMWare support for macOS infrastructure. "